### PR TITLE
Avoid instantiation of eager singleton on binging introspection phase.

### DIFF
--- a/extensions/activation/main/src/main/java/org/ops4j/peaberry/activation/internal/BundleActivation.java
+++ b/extensions/activation/main/src/main/java/org/ops4j/peaberry/activation/internal/BundleActivation.java
@@ -38,6 +38,7 @@ import org.osgi.framework.Bundle;
 import com.google.inject.Binding;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.Stage;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provider;
@@ -108,7 +109,7 @@ public class BundleActivation {
     this.roots = new ArrayList<BundleRoot>();
     
     /* A temporary Injector used to introspect the bindings */
-    final Injector injector = createInjector();
+    final Injector injector = createInjector(Stage.TOOL);
     
     /* Make mutable set of bindings to be consumed by the createXXX methods */
     final Set<Entry<Key<?>, Binding<?>>> bindings = new HashSet<Entry<Key<?>,Binding<?>>>();
@@ -179,7 +180,7 @@ public class BundleActivation {
     }
     active = true;
     
-    final Injector injector = createInjector();
+    final Injector injector = createInjector(Stage.DEVELOPMENT);
     
     for (BundleRoot r : roots) {
       r.activate(injector);
@@ -209,8 +210,8 @@ public class BundleActivation {
     }
   }
 
-  private Injector createInjector() {
-    return Guice.createInjector(Peaberry.osgiModule(bundle.getBundleContext()), module);
+  private Injector createInjector(Stage stage) {
+    return Guice.createInjector(stage, Peaberry.osgiModule(bundle.getBundleContext()), module);
   }
 
   private void createExports(final Injector injector, final Set<Entry<Key<?>, Binding<?>>> entries) {

--- a/extensions/activation/test/src/main/java/org/ops4j/peaberry/activation/examples/singleton/Config.java
+++ b/extensions/activation/test/src/main/java/org/ops4j/peaberry/activation/examples/singleton/Config.java
@@ -33,7 +33,7 @@ public class Config
 
   @Override
   protected void configure() {
-    bind(SingletonRoot.class).in(Singleton.class);
+    bind(SingletonRoot.class).asEagerSingleton();
 
     install(trackerModule(
       subclassesOf(SingletonRoot.class), 

--- a/extensions/activation/test/src/main/java/org/ops4j/peaberry/activation/examples/singleton/SingletonRoot.java
+++ b/extensions/activation/test/src/main/java/org/ops4j/peaberry/activation/examples/singleton/SingletonRoot.java
@@ -23,6 +23,13 @@ import org.ops4j.peaberry.activation.Stop;
  * @author rinsvind@gmail.com (Todor Boev)
  */
 public class SingletonRoot {
+
+  public static int instanceCounter = 0;
+
+  public SingletonRoot() {
+    instanceCounter++;
+  }
+
   @Start
   public void start() {
   }

--- a/extensions/activation/test/src/test/java/org/ops4j/peaberry/activation/tests/ActivtionTest.java
+++ b/extensions/activation/test/src/test/java/org/ops4j/peaberry/activation/tests/ActivtionTest.java
@@ -96,7 +96,7 @@ public class ActivtionTest extends InvocationTracking {
   @Test
   public void testSingletonRoot() 
     throws BundleException {
-    
+    SingletonRoot.instanceCounter = 0;
     activation.start();
     
     singletonRoot.start();
@@ -104,12 +104,13 @@ public class ActivtionTest extends InvocationTracking {
 
     singletonRoot.stop();
     assertInvoked(type(SingletonRoot.class), method("stop"));
+    assertEquals(1, SingletonRoot.instanceCounter);
   }
 
   @Test
   public void testExtenderRestart() 
     throws BundleException, InvalidSyntaxException {
-    
+    SingletonRoot.instanceCounter = 0;
     /* Extended bundles are active and waiting */
     exportRoot.start();
     assertNull(getReference(ExportRoot.class));
@@ -136,5 +137,6 @@ public class ActivtionTest extends InvocationTracking {
     activation.start();
     assertEquals(1, getReferenceList(ExportRoot.class).length);
     assertInvoked(type(SingletonRoot.class), method("start"));
+    assertEquals(2, SingletonRoot.instanceCounter);
   }
 }


### PR DESCRIPTION
When using asEagerSingleton() call on binding this singletons instantiate twice when using Peaberry Activation extension.
In suplied binding introspection phase is performed with TOOL Guice Injector stage witch not instantiate eager singletons.
